### PR TITLE
Update __init__.py

### DIFF
--- a/i2cpy/driver/ch341/__init__.py
+++ b/i2cpy/driver/ch341/__init__.py
@@ -79,7 +79,11 @@ class CH341(I2CDriverBase):
             raise I2COperationFailedError("CH341OpenDevice")
 
     def _init_posix(self):
-        buf = create_string_buffer(b"/dev/ch34x_pis0")
+        #buf = create_string_buffer(b"/dev/ch34x_pis0")
+        if type(self.device_path) == str:
+        	buf = create_string_buffer(bytes(self.device_path, 'utf8'))
+        else:
+        	buf = create_string_buffer(bytes('/dev/ch34x_pis' + str(self.device_path), 'utf8'))
         fd = ch341dll.CH341OpenDevice(buf)
         if fd > 0:
             self._fd = fd


### PR DESCRIPTION
Adaptation to multiport devices in Linux.
The original code only read data from a single device connected to '/dev/ch34x_pis0', even if there were other devices connected and different addresses were indicated (/dev/ch34x_pis1, 2...), it only read from port 0, repeating the readings on the rest.
The changes affect line 82 of the original file.
The modification allows to reference multiple CH341 circuits plugged into different USB ports in Linux.
Devices can be indicated by their full address in '/dev/ch34x_pis*' or simply by the ending number.