### PR TITLE
Restores I2c bus speed setup on ch347 driver

### DIFF
--- a/i2cpy/driver/ch347/__init__.py
+++ b/i2cpy/driver/ch347/__init__.py
@@ -23,16 +23,32 @@ class BaudRate(Enum):
     BAUD400K = 2
     BAUD750K = 3
 
+class BaudRate(Enum):
+    BAUD20K = 0
+    BAUD100K = 1
+    BAUD400K = 2
+    BAUD750K = 3
+    BAUD50K = 4
+    BAUD200K = 5
+    BAUD1M = 6
+
     @classmethod
     def from_number(cls, freq: int | float) -> BaudRate:
+        if freq >= 1000e3:
+            return BaudRate.BAUD1M
         if freq >= 750e3:
             return BaudRate.BAUD750K
         if freq >= 400e3:
             return BaudRate.BAUD400K
         if freq >= 100e3:
+            return BaudRate.BAUD200K
+        if freq >= 200e3:
+            return BaudRate.BAUD100K
+        if freq >= 100e3:
+            return BaudRate.BAUD50K
+        if freq >= 50e3:
             return BaudRate.BAUD100K
         return BaudRate.BAUD20K
-
 
 class CH347(I2CDriverBase):
     def __init__(self, id: Optional[int | str] = None, *, freq: int | float = 400000):
@@ -68,6 +84,8 @@ class CH347(I2CDriverBase):
 
     def _init_nt(self):
         if ch347dll.CH347OpenDevice(self._fd) != -1:
+            ret = ch347dll.CH347I2C_Set(self._fd, self.baudrate.value)
+            self._check_ret(ret, "CH347I2C_Set")
             # ret = ch347dll.CH347SetStream(self._fd, self.baudrate.value)
             # self._check_ret(ret, "CH341SetStream")
             pass

--- a/i2cpy/driver/ch347/__init__.py
+++ b/i2cpy/driver/ch347/__init__.py
@@ -16,13 +16,6 @@ from .dll import ch347dll
 from ..abc import I2CDriverBase, i2c_addr_byte, to_buffer, memaddr_to_bytes
 from ...errors import I2COperationFailedError
 
-
-class BaudRate(Enum):
-    BAUD20K = 0
-    BAUD100K = 1
-    BAUD400K = 2
-    BAUD750K = 3
-
 class BaudRate(Enum):
     BAUD20K = 0
     BAUD100K = 1

--- a/i2cpy/driver/ch347/dll.py
+++ b/i2cpy/driver/ch347/dll.py
@@ -32,6 +32,7 @@ def load() -> CDLL:
             # "CH347WiteData",
             # "CH347WriteRead",
             "CH347StreamI2CRetAck",
+            "CH347I2C_Set",
         ]
 
         for fname in funcs:


### PR DESCRIPTION
Actualy with my supepro i2c connection on my test setup cannot use speed more than 200000 but I tested all slower speed and are OK.