### PR TITLE
Check ACK from device

### DIFF
--- a/i2cpy/driver/ch347/__init__.py
+++ b/i2cpy/driver/ch347/__init__.py
@@ -127,8 +127,13 @@ class CH347(I2CDriverBase):
         else:
             nbytes = len(rbuf)
             obuf = (c_byte * nbytes).from_buffer(rbuf)
-        ret = ch347dll.CH347StreamI2C(self._fd, len(ibuf), ibuf, nbytes, obuf)
-        self._check_ret(ret, "CH347StreamI2C")
+        ack_count = c_ulong(0)
+        #ret = ch347dll.CH347StreamI2C(self._fd, len(ibuf), ibuf, nbytes, obuf)
+        ret = ch347dll.CH347StreamI2C_RetACK(self._fd, len(ibuf), ibuf, nbytes, obuf, byref(ack_count) )
+        if ack_count == 0:
+            raise I2COperationFailedError("No ACK received from device!")
+        self._check_ret(ret, "CH347StreamI2C_RetACK")
+
 
     def _write(self, buf: Buffer):
         self._writeread_into(buf, None)


### PR DESCRIPTION
Check the acks received from i2c device to test i2c device presence with ch347 driver.
No ack no device present.
This add a difference using ch347 or ch341 usb device with the same code.